### PR TITLE
Improve recording experience on iOS

### DIFF
--- a/client/src/components/PromptRecorder.jsx
+++ b/client/src/components/PromptRecorder.jsx
@@ -4,7 +4,7 @@ import VideoRecorder from './VideoRecorder';
 export default function PromptRecorder({ onFinish }) {
   async function handleRecorded(blob) {
     const formData = new FormData();
-    formData.append('video', blob, 'prompt.webm');
+    formData.append('video', blob, 'prompt.mp4');
     const res = await fetch('api/upload_prompt.php', {
       method: 'POST',
       body: formData,

--- a/client/src/components/ResponseRecorder.jsx
+++ b/client/src/components/ResponseRecorder.jsx
@@ -6,7 +6,7 @@ export default function ResponseRecorder({ promptId }) {
 
   async function handleRecorded(blob) {
     const formData = new FormData();
-    formData.append('video', blob, 'response.webm');
+    formData.append('video', blob, 'response.mp4');
     await fetch(`api/upload_response.php?prompt=${promptId}`, {
       method: 'POST',
       body: formData,


### PR DESCRIPTION
## Summary
- keep inline video playback while recording so iPhones don't jump to fullscreen
- use the recorded chunk's MIME type when creating the Blob so Safari previews work
- default to MP4 when supported for better iOS compatibility
- send `.mp4` files when uploading prompts or responses

## Testing
- `npm install`
- `npm run build`
- `php -l api/upload_response.php api/list_responses.php api/upload_prompt.php`


------
https://chatgpt.com/codex/tasks/task_e_686590499fa88326a0ebce48e0628bd3