### PR TITLE
Add secure video serving with HTTPS enforcement

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,8 @@
+RewriteEngine On
+RewriteCond %{HTTPS} off
+RewriteRule ^ https://%{HTTP_HOST}%{REQUEST_URI} [L,R=301]
+
+# Serve uploaded files via secure PHP script
+RewriteRule ^uploads/(.*)$ api/video.php?file=$1 [QSA,L]
+
+Options -Indexes

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This project is a simple web application that allows users to record short video
 
 ## Structure
 
-- `api` – PHP endpoints for uploading and listing videos.
+- `api` – PHP endpoints for authentication and video uploads.
 - `client` – Vite React application with Tailwind for styling.
 - `uploads` – Directory where uploaded videos are stored.
 
@@ -23,10 +23,20 @@ This project is a simple web application that allows users to record short video
    The built site will be output to `build/` when you run `npm run build`.
 3. **Serve with PHP** (after building):
    ```bash
-   php -S localhost:8000 -t build
+   php -S localhost:8000
    ```
 
+   The PHP built-in server should be started from the project root so the `api/`
+   endpoints are available.
+
 Uploaded videos are stored in the `uploads/` directory alongside the PHP scripts.
+Apache users should enable `.htaccess` so that HTTP requests are redirected to HTTPS and video files are served through `api/video.php` for authenticated sessions.
+
+## Login Flow
+
+1. Users enter their email address in the login form.
+2. A login link is emailed to them using the PHP backend.
+3. Following the link establishes a session which allows access to the recorders.
 
 ## Recording Flow
 
@@ -35,3 +45,9 @@ Uploaded videos are stored in the `uploads/` directory alongside the PHP scripts
 3. Responses are listed below the recorder.
 
 This simple setup demonstrates recording and playback of user-generated videos for storytelling.
+
+## Apache Configuration
+
+An `.htaccess` file is included to enforce HTTPS and route requests for files in
+`uploads/` through `api/video.php`. Make sure `AllowOverride` is enabled in your
+Apache configuration so these rules take effect.

--- a/api/auth.php
+++ b/api/auth.php
@@ -1,0 +1,29 @@
+<?php
+function require_https() {
+    if (empty($_SERVER['HTTPS']) || $_SERVER['HTTPS'] !== 'on') {
+        $url = 'https://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
+        header('Location: ' . $url, true, 301);
+        exit;
+    }
+}
+
+function start_session() {
+    if (session_status() === PHP_SESSION_NONE) {
+        session_start();
+    }
+}
+
+function require_login() {
+    start_session();
+    if (!isset($_SESSION['user'])) {
+        http_response_code(401);
+        echo json_encode(['error' => 'Authentication required']);
+        exit;
+    }
+}
+
+function check_login() {
+    start_session();
+    return isset($_SESSION['user']);
+}
+?>

--- a/api/check_login.php
+++ b/api/check_login.php
@@ -1,0 +1,5 @@
+<?php
+require_once __DIR__ . '/auth.php';
+require_https();
+header('Content-Type: application/json');
+echo json_encode(['authenticated' => check_login()]);

--- a/api/list_responses.php
+++ b/api/list_responses.php
@@ -1,6 +1,9 @@
 <?php
+require_once __DIR__ . '/auth.php';
+require_https();
+require_login();
 header('Content-Type: application/json');
-$prompt = $_GET['prompt'] ?? '';
+$prompt = basename($_GET['prompt'] ?? '');
 $metadataDir = __DIR__ . '/../metadata';
 $responsesFile = "$metadataDir/$prompt.json";
 if ($prompt === '' || !file_exists($responsesFile)) {

--- a/api/request_login.php
+++ b/api/request_login.php
@@ -1,0 +1,29 @@
+<?php
+require_once __DIR__ . '/auth.php';
+require_https();
+start_session();
+header('Content-Type: application/json');
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    echo json_encode(['error' => 'POST required']);
+    exit;
+}
+
+$email = $_POST['email'] ?? '';
+if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+    http_response_code(400);
+    echo json_encode(['error' => 'Invalid email']);
+    exit;
+}
+
+$token = bin2hex(random_bytes(16));
+$tokenDir = __DIR__ . '/../metadata/tokens';
+if (!is_dir($tokenDir)) {
+    mkdir($tokenDir, 0777, true);
+}
+file_put_contents("$tokenDir/$token.json", json_encode(['email' => $email, 'ts' => time()]));
+$link = 'https://' . $_SERVER['HTTP_HOST'] . '/api/verify_login.php?token=' . $token;
+@mail($email, 'Your login link', "Click this link to log in: $link");
+
+echo json_encode(['sent' => true]);

--- a/api/upload_prompt.php
+++ b/api/upload_prompt.php
@@ -1,4 +1,7 @@
 <?php
+require_once __DIR__ . '/auth.php';
+require_https();
+require_login();
 header('Content-Type: application/json');
 if ($_SERVER['REQUEST_METHOD'] !== 'POST' || !isset($_FILES['video'])) {
     http_response_code(400);

--- a/api/upload_response.php
+++ b/api/upload_response.php
@@ -1,6 +1,9 @@
 <?php
+require_once __DIR__ . '/auth.php';
+require_https();
+require_login();
 header('Content-Type: application/json');
-$prompt = $_GET['prompt'] ?? '';
+$prompt = basename($_GET['prompt'] ?? '');
 if ($prompt === '' || $_SERVER['REQUEST_METHOD'] !== 'POST' || !isset($_FILES['video'])) {
     http_response_code(400);
     echo json_encode(['error' => 'Invalid request']);

--- a/api/verify_login.php
+++ b/api/verify_login.php
@@ -1,0 +1,16 @@
+<?php
+require_once __DIR__ . '/auth.php';
+require_https();
+start_session();
+$token = $_GET['token'] ?? '';
+$tokenFile = __DIR__ . '/../metadata/tokens/' . basename($token) . '.json';
+if ($token !== '' && file_exists($tokenFile)) {
+    $data = json_decode(file_get_contents($tokenFile), true);
+    unlink($tokenFile);
+    $_SESSION['user'] = $data['email'];
+    header('Location: /');
+    exit;
+}
+header('Content-Type: text/plain');
+http_response_code(400);
+echo 'Invalid or expired token';

--- a/api/video.php
+++ b/api/video.php
@@ -1,0 +1,16 @@
+<?php
+require_once __DIR__ . '/auth.php';
+require_https();
+require_login();
+$filename = basename($_GET['file'] ?? '');
+$path = __DIR__ . '/../uploads/' . $filename;
+if ($filename === '' || !file_exists($path)) {
+    http_response_code(404);
+    echo 'Not found';
+    exit;
+}
+$mime = mime_content_type($path) ?: 'application/octet-stream';
+header('Content-Type: ' . $mime);
+header('Content-Disposition: inline; filename="' . $filename . '"');
+readfile($path);
+

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,10 +1,35 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import PromptRecorder from './components/PromptRecorder';
 import ResponseRecorder from './components/ResponseRecorder';
+import LoginForm from './components/LoginForm';
 
 export default function App() {
   const [promptId, setPromptId] = useState('');
   const [recordingPrompt, setRecordingPrompt] = useState(false);
+  const [authenticated, setAuthenticated] = useState(false);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetch('api/check_login.php')
+      .then((res) => res.json())
+      .then((data) => {
+        setAuthenticated(data.authenticated);
+        setLoading(false);
+      });
+  }, []);
+
+  if (loading) {
+    return null;
+  }
+
+  if (!authenticated) {
+    return (
+      <div className="container mx-auto p-4">
+        <h1 className="text-2xl font-bold mb-4">Video Stories</h1>
+        <LoginForm />
+      </div>
+    );
+  }
 
   return (
     <div className="container mx-auto p-4">

--- a/client/src/components/LoginForm.jsx
+++ b/client/src/components/LoginForm.jsx
@@ -1,0 +1,37 @@
+import React, { useState } from 'react';
+
+export default function LoginForm() {
+  const [email, setEmail] = useState('');
+  const [sent, setSent] = useState(false);
+
+  async function handleSubmit(e) {
+    e.preventDefault();
+    const formData = new FormData();
+    formData.append('email', email);
+    await fetch('api/request_login.php', {
+      method: 'POST',
+      body: formData,
+    });
+    setSent(true);
+  }
+
+  if (sent) {
+    return <p>Check your email for a login link.</p>;
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-x-2">
+      <input
+        type="email"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        required
+        className="border px-2 py-1"
+        placeholder="Email"
+      />
+      <button className="bg-blue-500 text-white px-4 py-1 rounded" type="submit">
+        Send Login Link
+      </button>
+    </form>
+  );
+}

--- a/client/src/components/ResponseRecorder.jsx
+++ b/client/src/components/ResponseRecorder.jsx
@@ -32,7 +32,11 @@ export default function ResponseRecorder({ promptId }) {
       <ul>
         {responses.map((r, i) => (
           <li key={i} className="mb-2">
-            <video src={`uploads/${r.filename}`} controls className="w-full" />
+            <video
+              src={`api/video.php?file=${encodeURIComponent(r.filename)}`}
+              controls
+              className="w-full"
+            />
           </li>
         ))}
       </ul>


### PR DESCRIPTION
## Summary
- redirect HTTP to HTTPS and protect uploads via `.htaccess`
- sanitize prompt parameters in PHP endpoints
- gate uploaded file access through new `api/video.php`
- update React app to load videos from the new endpoint
- document Apache setup and HTTPS enforcement in README

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6866bc52f534832698270b9bfeb9260b