### PR TITLE
Add DB init scripts and deploy config files

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,7 @@ SMTP_PORT=587
 SMTP_USER=user@example.com
 SMTP_PASS=secret
 SMTP_SECURE=tls
+# Database connection for whitelist and friends
+DB_DSN=pgsql:host=localhost;port=5432;dbname=stories
+DB_USER=stories
+DB_PASS=password

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,6 +31,7 @@ jobs:
       - name: Copy PHP backend
         run: |
           cp -r api uploads metadata build/
+          cp config.php .htaccess build/
 
       - name: Deploy to Bluehost via FTP/SFTP
         uses: SamKirkland/FTP-Deploy-Action@v4.3.0

--- a/api/db.php
+++ b/api/db.php
@@ -1,0 +1,19 @@
+<?php
+function db() {
+    static $pdo;
+    if (!$pdo) {
+        $config = require __DIR__ . '/../config.php';
+        $dsn = $config['db']['dsn'] ?? '';
+        if ($dsn === '') {
+            throw new RuntimeException('Database DSN not configured');
+        }
+        $user = $config['db']['user'] ?? '';
+        $pass = $config['db']['pass'] ?? '';
+        $options = $config['db']['options'] ?? [
+            PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+        ];
+        $pdo = new PDO($dsn, $user, $pass, $options);
+    }
+    return $pdo;
+}
+?>

--- a/api/list_friends.php
+++ b/api/list_friends.php
@@ -1,0 +1,9 @@
+<?php
+require_once __DIR__ . '/auth.php';
+require_https();
+require_login();
+start_session();
+header('Content-Type: application/json');
+$friends = $_SESSION['friends'] ?? [];
+echo json_encode($friends);
+?>

--- a/api/verify_login.php
+++ b/api/verify_login.php
@@ -8,6 +8,7 @@ if ($token !== '' && file_exists($tokenFile)) {
     $data = json_decode(file_get_contents($tokenFile), true);
     unlink($tokenFile);
     $_SESSION['user'] = $data['email'];
+    $_SESSION['friends'] = $data['friends'] ?? [];
     header('Location: /');
     exit;
 }

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import PromptRecorder from './components/PromptRecorder';
 import ResponseRecorder from './components/ResponseRecorder';
 import LoginForm from './components/LoginForm';
+import FriendList from './components/FriendList';
 
 export default function App() {
   const [promptId, setPromptId] = useState('');
@@ -34,6 +35,7 @@ export default function App() {
   return (
     <div className="container mx-auto p-4">
       <h1 className="text-2xl font-bold mb-4">Video Stories</h1>
+      <FriendList />
       {recordingPrompt ? (
         <PromptRecorder onFinish={(id) => { setPromptId(id); setRecordingPrompt(false); }} />
       ) : (

--- a/client/src/components/FriendList.jsx
+++ b/client/src/components/FriendList.jsx
@@ -1,0 +1,24 @@
+import React, { useEffect, useState } from 'react';
+
+export default function FriendList() {
+  const [friends, setFriends] = useState([]);
+
+  useEffect(() => {
+    fetch('api/list_friends.php')
+      .then((res) => res.json())
+      .then((data) => setFriends(data));
+  }, []);
+
+  if (!friends.length) return null;
+
+  return (
+    <div className="my-4">
+      <h2 className="text-xl mb-2">Friends</h2>
+      <ul className="list-disc list-inside">
+        {friends.map((f, i) => (
+          <li key={i}>{f}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/client/src/components/LoginForm.jsx
+++ b/client/src/components/LoginForm.jsx
@@ -3,16 +3,23 @@ import React, { useState } from 'react';
 export default function LoginForm() {
   const [email, setEmail] = useState('');
   const [sent, setSent] = useState(false);
+  const [error, setError] = useState('');
 
   async function handleSubmit(e) {
     e.preventDefault();
     const formData = new FormData();
     formData.append('email', email);
-    await fetch('api/request_login.php', {
+    const res = await fetch('api/request_login.php', {
       method: 'POST',
       body: formData,
     });
-    setSent(true);
+    const data = await res.json();
+    if (res.ok) {
+      setSent(true);
+      setError('');
+    } else {
+      setError(data.error || 'Request failed');
+    }
   }
 
   if (sent) {
@@ -20,18 +27,21 @@ export default function LoginForm() {
   }
 
   return (
-    <form onSubmit={handleSubmit} className="space-x-2">
-      <input
-        type="email"
-        value={email}
-        onChange={(e) => setEmail(e.target.value)}
-        required
-        className="border px-2 py-1"
-        placeholder="Email"
-      />
-      <button className="bg-blue-500 text-white px-4 py-1 rounded" type="submit">
-        Send Login Link
-      </button>
-    </form>
+    <div>
+      <form onSubmit={handleSubmit} className="space-x-2">
+        <input
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+          className="border px-2 py-1"
+          placeholder="Email"
+        />
+        <button className="bg-blue-500 text-white px-4 py-1 rounded" type="submit">
+          Send Login Link
+        </button>
+      </form>
+      {error && <p className="text-red-600 mt-2">{error}</p>}
+    </div>
   );
 }

--- a/config.php
+++ b/config.php
@@ -26,5 +26,14 @@ return [
             'password' => getenv('SMTP_PASS') ?: '',
             'secure' => getenv('SMTP_SECURE') ?: 'tls'
         ]
+    ],
+    'db' => [
+        'dsn' => getenv('DB_DSN') ?: '',
+        'user' => getenv('DB_USER') ?: '',
+        'pass' => getenv('DB_PASS') ?: '',
+        // Options can be overridden via DB_OPTIONS JSON
+        'options' => getenv('DB_OPTIONS') ? json_decode(getenv('DB_OPTIONS'), true) : [
+            PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION
+        ]
     ]
 ];

--- a/database/README.md
+++ b/database/README.md
@@ -1,0 +1,22 @@
+# Database Setup
+
+The `init.sql` script provisions the initial database schema used by the
+application. Apply it to an empty database using psql:
+
+```bash
+psql -U stories -f init.sql
+```
+
+## Migrations
+
+Database changes are tracked in the `migrations/` directory as sequential SQL
+files. When updating your deployment, apply any new migrations in order:
+
+```bash
+psql -U stories -f migrations/001_initial.sql
+# later migrations
+psql -U stories -f migrations/002_some_change.sql
+```
+
+This simple scheme keeps the SQL files under version control so the schema can
+be evolved gradually.

--- a/database/init.sql
+++ b/database/init.sql
@@ -1,0 +1,11 @@
+-- Initial schema for Video Stories
+
+CREATE TABLE IF NOT EXISTS users (
+  id SERIAL PRIMARY KEY,
+  email TEXT UNIQUE NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS friends (
+  user_id INTEGER NOT NULL REFERENCES users(id),
+  friend_user_id INTEGER NOT NULL REFERENCES users(id)
+);

--- a/database/migrations/001_initial.sql
+++ b/database/migrations/001_initial.sql
@@ -1,0 +1,11 @@
+-- Migration 001: initial database schema
+
+CREATE TABLE users (
+  id SERIAL PRIMARY KEY,
+  email TEXT UNIQUE NOT NULL
+);
+
+CREATE TABLE friends (
+  user_id INTEGER NOT NULL REFERENCES users(id),
+  friend_user_id INTEGER NOT NULL REFERENCES users(id)
+);


### PR DESCRIPTION
## Summary
- deploy `config.php` and `.htaccess` with the rest of the build
- document automatic deployment of these files
- add `database/` folder with `init.sql` and first migration
- describe migration approach in README

## Testing
- `npm install` *(fails: Could not read package.json)*
- `npm install --prefix client`
- `npm run build --prefix client`
- `npm test --prefix client` *(fails: Missing script "test")*
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b1ccea5148326ae37023c7c28e7f7