### PR TITLE
Add logout endpoint and user menu UI

### DIFF
--- a/api/check_login.php
+++ b/api/check_login.php
@@ -1,5 +1,13 @@
 <?php
 require_once __DIR__ . '/auth.php';
 require_https();
+start_session();
 header('Content-Type: application/json');
-echo json_encode(['authenticated' => check_login()]);
+
+$authenticated = check_login();
+$response = ['authenticated' => $authenticated];
+if ($authenticated) {
+    $response['user'] = $_SESSION['user'] ?? null;
+}
+
+echo json_encode($response);

--- a/api/logout.php
+++ b/api/logout.php
@@ -1,0 +1,16 @@
+<?php
+require_once __DIR__ . '/auth.php';
+require_https();
+start_session();
+$_SESSION = [];
+if (ini_get('session.use_cookies')) {
+    $params = session_get_cookie_params();
+    setcookie(session_name(), '', time() - 42000,
+        $params['path'], $params['domain'],
+        $params['secure'], $params['httponly']
+    );
+}
+session_destroy();
+header('Content-Type: application/json');
+echo json_encode(['loggedOut' => true]);
+

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -3,11 +3,13 @@ import PromptRecorder from './components/PromptRecorder';
 import ResponseRecorder from './components/ResponseRecorder';
 import LoginForm from './components/LoginForm';
 import FriendList from './components/FriendList';
+import UserMenu from './components/UserMenu';
 
 export default function App() {
   const [promptId, setPromptId] = useState('');
   const [recordingPrompt, setRecordingPrompt] = useState(false);
   const [authenticated, setAuthenticated] = useState(false);
+  const [user, setUser] = useState(null);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
@@ -15,6 +17,7 @@ export default function App() {
       .then((res) => res.json())
       .then((data) => {
         setAuthenticated(data.authenticated);
+        setUser(data.user || null);
         setLoading(false);
       });
   }, []);
@@ -32,9 +35,19 @@ export default function App() {
     );
   }
 
+  function handleLogout() {
+    fetch('api/logout.php').then(() => {
+      setAuthenticated(false);
+      setUser(null);
+    });
+  }
+
   return (
     <div className="container mx-auto p-4">
-      <h1 className="text-2xl font-bold mb-4">Video Stories</h1>
+      <div className="flex justify-between items-center mb-4">
+        <h1 className="text-2xl font-bold">Video Stories</h1>
+        <UserMenu user={user} onLogout={handleLogout} />
+      </div>
       <FriendList />
       {recordingPrompt ? (
         <PromptRecorder onFinish={(id) => { setPromptId(id); setRecordingPrompt(false); }} />

--- a/client/src/components/UserMenu.jsx
+++ b/client/src/components/UserMenu.jsx
@@ -1,0 +1,48 @@
+import React, { useState, useRef, useEffect } from 'react';
+
+export default function UserMenu({ user, onLogout }) {
+  const [open, setOpen] = useState(false);
+  const menuRef = useRef(null);
+
+  useEffect(() => {
+    function handleClick(e) {
+      if (menuRef.current && !menuRef.current.contains(e.target)) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener('click', handleClick);
+    return () => document.removeEventListener('click', handleClick);
+  }, []);
+
+  const avatar = user ? user.charAt(0).toUpperCase() : '?';
+
+  return (
+    <div className="relative" ref={menuRef}>
+      <button
+        className="w-8 h-8 rounded-full bg-gray-300 flex items-center justify-center text-sm"
+        onClick={() => setOpen(!open)}
+      >
+        {avatar}
+      </button>
+      {open && (
+        <div className="absolute right-0 mt-2 bg-white border rounded shadow-md text-sm">
+          <button
+            className="block px-4 py-2 hover:bg-gray-100 w-full text-left"
+            onClick={() => setOpen(false)}
+          >
+            Settings
+          </button>
+          <button
+            className="block px-4 py-2 hover:bg-gray-100 w-full text-left"
+            onClick={() => {
+              setOpen(false);
+              onLogout();
+            }}
+          >
+            Logout
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- return email from `check_login.php` for frontend
- add `logout.php` endpoint to end the session
- show user avatar with dropdown menu
- include logout handling in React app
- add `UserMenu` React component

## Testing
- `npm install`
- `npm run build`
- `php -l api/check_login.php` *(fails: `php` not found)*
- `php -l api/logout.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ec00fa01083269c97f1065bf29d49