### PR TITLE
Add user profile editing with avatars

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,9 @@ Two tables are expected:
 ```
 CREATE TABLE users (
   id SERIAL PRIMARY KEY,
-  email TEXT UNIQUE NOT NULL
+  email TEXT UNIQUE NOT NULL,
+  username TEXT,
+  avatar TEXT
 );
 
 CREATE TABLE friends (

--- a/api/request_login.php
+++ b/api/request_login.php
@@ -30,17 +30,13 @@ if (!$userId) {
     exit;
 }
 
-// Load friend email addresses for the login request
-$friendStmt = $pdo->prepare('SELECT u2.email FROM friends f JOIN users u2 ON f.friend_user_id = u2.id WHERE f.user_id = ?');
-$friendStmt->execute([$userId]);
-$friends = $friendStmt->fetchAll(PDO::FETCH_COLUMN);
 
 $token = bin2hex(random_bytes(16));
 $tokenDir = __DIR__ . '/../metadata/tokens';
 if (!is_dir($tokenDir)) {
     mkdir($tokenDir, 0777, true);
 }
-$tokenData = ['email' => $email, 'ts' => time(), 'friends' => $friends];
+$tokenData = ['email' => $email, 'ts' => time()];
 file_put_contents("$tokenDir/$token.json", json_encode($tokenData));
 $link = 'https://' . $_SERVER['HTTP_HOST'] . '/api/verify_login.php?token=' . $token;
 // send email using config

--- a/api/update_profile.php
+++ b/api/update_profile.php
@@ -1,0 +1,44 @@
+<?php
+require_once __DIR__ . '/auth.php';
+require_once __DIR__ . '/db.php';
+require_https();
+require_login();
+start_session();
+header('Content-Type: application/json');
+
+$user = $_SESSION['user'];
+$pdo = db();
+
+$username = $_POST['username'] ?? null;
+$avatarFile = $_FILES['avatar']['tmp_name'] ?? null;
+$updates = [];
+$params = [];
+
+if ($username !== null) {
+    $updates[] = 'username = ?';
+    $params[] = $username;
+    $_SESSION['user']['username'] = $username;
+}
+
+if ($avatarFile) {
+    $avatarsDir = __DIR__ . '/../uploads/avatars';
+    if (!is_dir($avatarsDir)) {
+        mkdir($avatarsDir, 0777, true);
+    }
+    $ext = pathinfo($_FILES['avatar']['name'], PATHINFO_EXTENSION);
+    $filename = uniqid() . ($ext ? '.' . $ext : '');
+    move_uploaded_file($avatarFile, "$avatarsDir/$filename");
+    $updates[] = 'avatar = ?';
+    $params[] = $filename;
+    $_SESSION['user']['avatar'] = $filename;
+}
+
+if ($updates) {
+    $params[] = $user['id'];
+    $sql = 'UPDATE users SET ' . implode(', ', $updates) . ' WHERE id = ?';
+    $stmt = $pdo->prepare($sql);
+    $stmt->execute($params);
+}
+
+echo json_encode(['user' => $_SESSION['user']]);
+

--- a/api/verify_login.php
+++ b/api/verify_login.php
@@ -1,5 +1,6 @@
 <?php
 require_once __DIR__ . '/auth.php';
+require_once __DIR__ . '/db.php';
 require_https();
 start_session();
 $token = $_GET['token'] ?? '';
@@ -7,8 +8,24 @@ $tokenFile = __DIR__ . '/../metadata/tokens/' . basename($token) . '.json';
 if ($token !== '' && file_exists($tokenFile)) {
     $data = json_decode(file_get_contents($tokenFile), true);
     unlink($tokenFile);
-    $_SESSION['user'] = $data['email'];
-    $_SESSION['friends'] = $data['friends'] ?? [];
+    $email = $data['email'];
+
+    $pdo = db();
+    $stmt = $pdo->prepare('SELECT id, email, username, avatar FROM users WHERE email = ?');
+    $stmt->execute([$email]);
+    $user = $stmt->fetch(PDO::FETCH_ASSOC);
+    if (!$user) {
+        http_response_code(400);
+        echo 'Invalid user';
+        exit;
+    }
+
+    $friendStmt = $pdo->prepare('SELECT u.id, u.email, u.username, u.avatar FROM friends f JOIN users u ON f.friend_user_id = u.id WHERE f.user_id = ?');
+    $friendStmt->execute([$user['id']]);
+    $friends = $friendStmt->fetchAll(PDO::FETCH_ASSOC);
+
+    $_SESSION['user'] = $user;
+    $_SESSION['friends'] = $friends;
     header('Location: /');
     exit;
 }

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -4,6 +4,7 @@ import ResponseRecorder from './components/ResponseRecorder';
 import LoginForm from './components/LoginForm';
 import FriendList from './components/FriendList';
 import UserMenu from './components/UserMenu';
+import Profile from './components/Profile';
 
 export default function App() {
   const [promptId, setPromptId] = useState('');
@@ -11,6 +12,7 @@ export default function App() {
   const [authenticated, setAuthenticated] = useState(false);
   const [user, setUser] = useState(null);
   const [loading, setLoading] = useState(true);
+  const [showProfile, setShowProfile] = useState(false);
 
   useEffect(() => {
     fetch('api/check_login.php')
@@ -42,12 +44,19 @@ export default function App() {
     });
   }
 
+  function handleProfileUpdated(u) {
+    setUser(u);
+  }
+
   return (
     <div className="container mx-auto p-4">
       <div className="flex justify-between items-center mb-4">
         <h1 className="text-2xl font-bold">Video Stories</h1>
-        <UserMenu user={user} onLogout={handleLogout} />
+        <UserMenu user={user} onLogout={handleLogout} onProfile={() => setShowProfile(true)} />
       </div>
+      {showProfile && (
+        <Profile user={user} onUpdated={handleProfileUpdated} onClose={() => setShowProfile(false)} />
+      )}
       <FriendList />
       {recordingPrompt ? (
         <PromptRecorder onFinish={(id) => { setPromptId(id); setRecordingPrompt(false); }} />

--- a/client/src/components/FriendList.jsx
+++ b/client/src/components/FriendList.jsx
@@ -14,9 +14,21 @@ export default function FriendList() {
   return (
     <div className="my-4">
       <h2 className="text-xl mb-2">Friends</h2>
-      <ul className="list-disc list-inside">
+      <ul className="space-y-2">
         {friends.map((f, i) => (
-          <li key={i}>{f}</li>
+          <li key={i} className="flex items-center space-x-2">
+            {f.avatar ? (
+              <img src={`uploads/avatars/${f.avatar}`} alt="avatar" className="w-8 h-8 rounded-full object-cover" />
+            ) : (
+              <div className="w-8 h-8 rounded-full bg-gray-300 flex items-center justify-center text-sm">
+                {(f.username || f.email).charAt(0).toUpperCase()}
+              </div>
+            )}
+            <div>
+              <div className="font-semibold">{f.username || f.email}</div>
+              <div className="text-sm text-gray-600">{f.email}</div>
+            </div>
+          </li>
         ))}
       </ul>
     </div>

--- a/client/src/components/Profile.jsx
+++ b/client/src/components/Profile.jsx
@@ -1,0 +1,61 @@
+import React, { useState } from 'react';
+
+export default function Profile({ user, onUpdated, onClose }) {
+  const [username, setUsername] = useState(user.username || '');
+  const [avatar, setAvatar] = useState(null);
+  const [saving, setSaving] = useState(false);
+
+  async function handleSubmit(e) {
+    e.preventDefault();
+    setSaving(true);
+    const formData = new FormData();
+    formData.append('username', username);
+    if (avatar) formData.append('avatar', avatar);
+    const res = await fetch('api/update_profile.php', {
+      method: 'POST',
+      body: formData,
+    });
+    const data = await res.json();
+    setSaving(false);
+    onUpdated(data.user);
+    onClose();
+  }
+
+  return (
+    <div className="border p-4 rounded mb-4">
+      <h2 className="text-xl mb-2">Profile</h2>
+      <form onSubmit={handleSubmit} className="space-y-2">
+        <div>
+          <label className="block mb-1">Username</label>
+          <input
+            type="text"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+            className="border px-2 py-1 w-full"
+          />
+        </div>
+        <div>
+          <label className="block mb-1">Avatar</label>
+          <input
+            type="file"
+            accept="image/*"
+            onChange={(e) => setAvatar(e.target.files[0])}
+          />
+        </div>
+        <div className="space-x-2">
+          <button
+            type="submit"
+            className="bg-blue-500 text-white px-4 py-1 rounded"
+            disabled={saving}
+          >
+            Save
+          </button>
+          <button type="button" onClick={onClose} className="px-4 py-1 border rounded">
+            Cancel
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}
+

--- a/client/src/components/UserMenu.jsx
+++ b/client/src/components/UserMenu.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useRef, useEffect } from 'react';
 
-export default function UserMenu({ user, onLogout }) {
+export default function UserMenu({ user, onLogout, onProfile }) {
   const [open, setOpen] = useState(false);
   const menuRef = useRef(null);
 
@@ -14,23 +14,32 @@ export default function UserMenu({ user, onLogout }) {
     return () => document.removeEventListener('click', handleClick);
   }, []);
 
-  const avatar = user ? user.charAt(0).toUpperCase() : '?';
+  const avatarLetter = user && (user.username || user.email)
+    ? (user.username || user.email).charAt(0).toUpperCase()
+    : '?';
 
   return (
     <div className="relative" ref={menuRef}>
       <button
-        className="w-8 h-8 rounded-full bg-gray-300 flex items-center justify-center text-sm"
+        className="w-8 h-8 rounded-full bg-gray-300 flex items-center justify-center text-sm overflow-hidden"
         onClick={() => setOpen(!open)}
       >
-        {avatar}
+        {user && user.avatar ? (
+          <img src={`uploads/avatars/${user.avatar}`} alt="avatar" className="w-full h-full object-cover" />
+        ) : (
+          avatarLetter
+        )}
       </button>
       {open && (
         <div className="absolute right-0 mt-2 bg-white border rounded shadow-md text-sm">
           <button
             className="block px-4 py-2 hover:bg-gray-100 w-full text-left"
-            onClick={() => setOpen(false)}
+            onClick={() => {
+              setOpen(false);
+              onProfile();
+            }}
           >
-            Settings
+            Profile
           </button>
           <button
             className="block px-4 py-2 hover:bg-gray-100 w-full text-left"

--- a/database/init.sql
+++ b/database/init.sql
@@ -2,7 +2,9 @@
 
 CREATE TABLE IF NOT EXISTS users (
   id SERIAL PRIMARY KEY,
-  email TEXT UNIQUE NOT NULL
+  email TEXT UNIQUE NOT NULL,
+  username TEXT,
+  avatar TEXT
 );
 
 CREATE TABLE IF NOT EXISTS friends (

--- a/database/migrations/002_add_profile_fields.sql
+++ b/database/migrations/002_add_profile_fields.sql
@@ -1,0 +1,3 @@
+-- Migration 002: add username and avatar columns
+ALTER TABLE users ADD COLUMN username TEXT;
+ALTER TABLE users ADD COLUMN avatar TEXT;


### PR DESCRIPTION
## Summary
- support username and avatar fields in DB schema
- add SQL migration for profile fields
- display friend avatars & usernames in FriendList
- add profile editing UI with avatar upload
- update session handling to include profile info

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686edaf2841c832687c257fc8d7d5c99