### PR TITLE
Add prompt email sending and playback

### DIFF
--- a/api/upload_prompt.php
+++ b/api/upload_prompt.php
@@ -1,5 +1,7 @@
 <?php
 require_once __DIR__ . '/auth.php';
+require_once __DIR__ . '/db.php';
+$config = require __DIR__ . '/../config.php';
 require_https();
 require_login();
 header('Content-Type: application/json');
@@ -15,5 +17,51 @@ if (!is_dir($uploadsDir)) {
 $id = time();
 $filename = $id . '-' . basename($_FILES['video']['name']);
 move_uploaded_file($_FILES['video']['tmp_name'], "$uploadsDir/$filename");
+
+$friendId = intval($_POST['friend_id'] ?? 0);
+if ($friendId > 0) {
+    $pdo = db();
+    $stmt = $pdo->prepare('SELECT email FROM users WHERE id = ?');
+    $stmt->execute([$friendId]);
+    $friendEmail = $stmt->fetchColumn();
+    if ($friendEmail) {
+        $token = bin2hex(random_bytes(16));
+        $tokenDir = __DIR__ . '/../metadata/tokens';
+        if (!is_dir($tokenDir)) {
+            mkdir($tokenDir, 0777, true);
+        }
+        $tokenData = ['email' => $friendEmail, 'ts' => time()];
+        file_put_contents("$tokenDir/$token.json", json_encode($tokenData));
+        $link = 'https://' . $_SERVER['HTTP_HOST'] . '/api/verify_login.php?token=' . $token . '&prompt=' . rawurlencode($filename);
+
+        require_once __DIR__ . '/../vendor/autoload.php';
+        $subject = 'New video prompt';
+        $message = "You have a new video prompt. View it here: $link";
+
+        if (!empty($config['email']['smtp']['host'])) {
+            $mail = new PHPMailer\PHPMailer\PHPMailer(true);
+            $mail->isSMTP();
+            $mail->Host = $config['email']['smtp']['host'];
+            $mail->Port = $config['email']['smtp']['port'];
+            if (!empty($config['email']['smtp']['username'])) {
+                $mail->SMTPAuth = true;
+                $mail->Username = $config['email']['smtp']['username'];
+                $mail->Password = $config['email']['smtp']['password'];
+            }
+            if (!empty($config['email']['smtp']['secure'])) {
+                $mail->SMTPSecure = $config['email']['smtp']['secure'];
+            }
+            $mail->setFrom($config['email']['from']);
+            $mail->addAddress($friendEmail);
+            $mail->Subject = $subject;
+            $mail->Body = $message;
+            $mail->send();
+        } else {
+            $headers = 'From: ' . $config['email']['from'] . "\r\n";
+            @mail($friendEmail, $subject, $message, $headers);
+        }
+    }
+}
+
 echo json_encode(['filename' => $filename]);
 

--- a/api/verify_login.php
+++ b/api/verify_login.php
@@ -2,6 +2,7 @@
 require_once __DIR__ . '/auth.php';
 require_once __DIR__ . '/db.php';
 require_https();
+$prompt = basename($_GET['prompt'] ?? '');
 start_session();
 $token = $_GET['token'] ?? '';
 $tokenFile = __DIR__ . '/../metadata/tokens/' . basename($token) . '.json';
@@ -26,7 +27,11 @@ if ($token !== '' && file_exists($tokenFile)) {
 
     $_SESSION['user'] = $user;
     $_SESSION['friends'] = $friends;
-    header('Location: /');
+    $redirect = '/';
+    if ($prompt !== '') {
+        $redirect .= '?prompt=' . rawurlencode($prompt);
+    }
+    header('Location: ' . $redirect);
     exit;
 }
 header('Content-Type: text/plain');

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -7,7 +7,9 @@ import UserMenu from './components/UserMenu';
 import Profile from './components/Profile';
 
 export default function App() {
-  const [promptId, setPromptId] = useState('');
+  const [promptId, setPromptId] = useState(() => {
+    return new URLSearchParams(window.location.search).get('prompt') || '';
+  });
   const [targetFriend, setTargetFriend] = useState(null);
   const [authenticated, setAuthenticated] = useState(false);
   const [user, setUser] = useState(null);
@@ -63,6 +65,9 @@ export default function App() {
           friend={targetFriend}
           onFinish={(id) => {
             setPromptId(id);
+            const url = new URL(window.location);
+            url.searchParams.set('prompt', id);
+            window.history.replaceState(null, '', url);
             setTargetFriend(null);
           }}
         />

--- a/client/src/components/PromptRecorder.jsx
+++ b/client/src/components/PromptRecorder.jsx
@@ -1,15 +1,19 @@
-import React from 'react';
+import React, { useState } from 'react';
 import VideoRecorder from './VideoRecorder';
 
 export default function PromptRecorder({ friend, onFinish }) {
+  const [uploading, setUploading] = useState(false);
   async function handleRecorded(blob) {
+    setUploading(true);
     const formData = new FormData();
     formData.append('video', blob, 'prompt.mp4');
+    formData.append('friend_id', friend.id);
     const res = await fetch('api/upload_prompt.php', {
       method: 'POST',
       body: formData,
     });
     const data = await res.json();
+    setUploading(false);
     onFinish(data.filename);
   }
 
@@ -18,7 +22,13 @@ export default function PromptRecorder({ friend, onFinish }) {
       <h2 className="text-xl mb-2">
         Record a Prompt for {friend.username || friend.email}
       </h2>
-      <VideoRecorder onRecorded={handleRecorded} />
+      {uploading ? (
+        <div className="flex justify-center items-center h-32">
+          <div className="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-gray-900"></div>
+        </div>
+      ) : (
+        <VideoRecorder onRecorded={handleRecorded} />
+      )}
     </div>
   );
 }

--- a/client/src/components/ResponseRecorder.jsx
+++ b/client/src/components/ResponseRecorder.jsx
@@ -27,6 +27,11 @@ export default function ResponseRecorder({ promptId }) {
   return (
     <div>
       <h2 className="text-xl mb-2">Respond to Prompt</h2>
+      <video
+        src={`api/video.php?file=${encodeURIComponent(promptId)}`}
+        controls
+        className="w-full mb-4"
+      />
       <VideoRecorder onRecorded={handleRecorded} />
       <h3 className="text-lg mt-4 mb-2">Responses</h3>
       <ul>


### PR DESCRIPTION
## Summary
- notify a selected friend when a prompt is uploaded
- show a spinner while the prompt upload is in progress
- include prompt id in the login link so the friend can see the video
- display the recorded prompt video to the friend
- keep the prompt id in the URL after recording

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686f32cf4b808326be34fbb474ca98e2