### PR TITLE
Expire login links after 15 minutes

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,10 @@ Apache users should enable `.htaccess` so that HTTP requests are redirected to H
 2. The backend checks the address against the whitelist stored in PostgreSQL.
    If it isn't found the request is rejected.
 3. When recognised, the server emails a login link and stores any associated
-   friend accounts with the token.
+   friend accounts with the token. The link is only valid for 15 minutes.
 4. Following the link establishes a session which includes the user's friend
-   list so it can be queried from the client.
+   list so it can be queried from the client. If the link has expired, the
+   user is shown a form to request a new one.
 
 ## Recording Flow
 

--- a/api/request_login.php
+++ b/api/request_login.php
@@ -43,7 +43,7 @@ $link = 'https://' . $_SERVER['HTTP_HOST'] . '/api/verify_login.php?token=' . $t
 require_once __DIR__ . '/../vendor/autoload.php';
 
 $subject = 'Your login link';
-$message = "Click this link to log in: $link";
+$message = "Click this link to log in: $link\nThis link will expire in 15 minutes.";
 
 if (!empty($config['email']['smtp']['host'])) {
     $mail = new PHPMailer\PHPMailer\PHPMailer(true);

--- a/api/verify_login.php
+++ b/api/verify_login.php
@@ -8,8 +8,20 @@ $token = $_GET['token'] ?? '';
 $tokenFile = __DIR__ . '/../metadata/tokens/' . basename($token) . '.json';
 if ($token !== '' && file_exists($tokenFile)) {
     $data = json_decode(file_get_contents($tokenFile), true);
+    $email = $data['email'] ?? '';
+    $created = $data['ts'] ?? 0;
+    $expired = (time() - $created) > 900; // 15 minutes
     unlink($tokenFile);
-    $email = $data['email'];
+    if ($expired) {
+        header('Content-Type: text/html; charset=UTF-8');
+        echo '<!DOCTYPE html><html><body>';
+        echo '<p>Login link expired. Request a new link below.</p>';
+        echo '<form method="post" action="/api/request_login.php">';
+        echo '<input type="email" name="email" required placeholder="Email" />';
+        echo '<button type="submit">Send Login Link</button>';
+        echo '</form></body></html>';
+        exit;
+    }
 
     $pdo = db();
     $stmt = $pdo->prepare('SELECT id, email, username, avatar FROM users WHERE email = ?');


### PR DESCRIPTION
## Summary
- invalidate login tokens if older than 15 minutes
- show a simple form when a token is expired so users can request another link
- mention token expiry in email message
- document link expiry in the README

## Testing
- `php -l api/request_login.php`
- `php -l api/verify_login.php`
- `npm install --silent`
- `npm run build --silent`

------
https://chatgpt.com/codex/tasks/task_e_6873ae445b508326b78b7d85fd8718ba