### PR TITLE
Add routing scaffolding

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "dependencies": {
         "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react-dom": "^18.2.0",
+        "react-router-dom": "^6.30.1"
       },
       "devDependencies": {
         "@vitejs/plugin-react": "^4.6.0",
@@ -813,6 +814,15 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
+      "integrity": "sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -2361,6 +2371,38 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.1.tgz",
+      "integrity": "sha512-X1m21aEmxGXqENEPG3T6u0Th7g0aS4ZmoNynhbs+Cn+q+QGTLt+d5IQ2bHAXKzKcxGJjxACpVbnYQSCRcfxHlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.1.tgz",
+      "integrity": "sha512-llKsgOkZdbPU1Eg3zK8lCn+sjD9wMRZZPuzmdWWX5SUs8OFkN5HnFVC0u5KMeMaC9aoancFI/KoLuKPqN+hxHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0",
+        "react-router": "6.30.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/read-cache": {

--- a/client/package.json
+++ b/client/package.json
@@ -8,13 +8,14 @@
   },
   "dependencies": {
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.30.1"
   },
   "devDependencies": {
-    "vite": "^5.2.0",
-    "tailwindcss": "^3.4.0",
-    "postcss": "^8.4.34",
+    "@vitejs/plugin-react": "^4.6.0",
     "autoprefixer": "^10.4.19",
-    "@vitejs/plugin-react": "^4.6.0"
+    "postcss": "^8.4.34",
+    "tailwindcss": "^3.4.0",
+    "vite": "^5.2.0"
   }
 }

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,82 +1,25 @@
-import React, { useState, useEffect } from 'react';
-import PromptRecorder from './components/PromptRecorder';
-import ResponseRecorder from './components/ResponseRecorder';
-import LoginForm from './components/LoginForm';
-import FriendList from './components/FriendList';
-import UserMenu from './components/UserMenu';
-import Profile from './components/Profile';
+import React from 'react';
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import Home from './pages/Home';
+import Login from './pages/Login';
+import Logout from './pages/Logout';
+import Prompts from './pages/Prompts';
+import Stories from './pages/Stories';
+import ProfilePage from './pages/ProfilePage';
+import Nav from './components/Nav';
 
 export default function App() {
-  const [promptId, setPromptId] = useState(() => {
-    return new URLSearchParams(window.location.search).get('prompt') || '';
-  });
-  const [targetFriend, setTargetFriend] = useState(null);
-  const [authenticated, setAuthenticated] = useState(false);
-  const [user, setUser] = useState(null);
-  const [loading, setLoading] = useState(true);
-  const [showProfile, setShowProfile] = useState(false);
-
-  useEffect(() => {
-    fetch('api/check_login.php')
-      .then((res) => res.json())
-      .then((data) => {
-        setAuthenticated(data.authenticated);
-        setUser(data.user || null);
-        setLoading(false);
-      });
-  }, []);
-
-  if (loading) {
-    return null;
-  }
-
-  if (!authenticated) {
-    return (
-      <div className="container mx-auto p-4">
-        <h1 className="text-2xl font-bold mb-4">Video Stories</h1>
-        <LoginForm />
-      </div>
-    );
-  }
-
-  function handleLogout() {
-    fetch('api/logout.php').then(() => {
-      setAuthenticated(false);
-      setUser(null);
-    });
-  }
-
-  function handleProfileUpdated(u) {
-    setUser(u);
-  }
-
   return (
-    <div className="container mx-auto p-4">
-      <div className="flex justify-between items-center mb-4">
-        <h1 className="text-2xl font-bold">Video Stories</h1>
-        <UserMenu user={user} onLogout={handleLogout} onProfile={() => setShowProfile(true)} />
-      </div>
-      {showProfile && (
-        <Profile user={user} onUpdated={handleProfileUpdated} onClose={() => setShowProfile(false)} />
-      )}
-      <FriendList onPrompt={(f) => setTargetFriend(f)} />
-      {targetFriend && (
-        <PromptRecorder
-          friend={targetFriend}
-          onFinish={(id) => {
-            setPromptId(id);
-            const url = new URL(window.location);
-            url.searchParams.set('prompt', id);
-            window.history.replaceState(null, '', url);
-            setTargetFriend(null);
-          }}
-        />
-      )}
-      {promptId && (
-        <div className="mt-6">
-          <ResponseRecorder promptId={promptId} />
-        </div>
-      )}
-    </div>
+    <BrowserRouter>
+      <Nav />
+      <Routes>
+        <Route path="/" element={<Home />} />
+        <Route path="/login" element={<Login />} />
+        <Route path="/logout" element={<Logout />} />
+        <Route path="/prompts" element={<Prompts />} />
+        <Route path="/stories" element={<Stories />} />
+        <Route path="/profile" element={<ProfilePage />} />
+      </Routes>
+    </BrowserRouter>
   );
 }

--- a/client/src/components/Nav.jsx
+++ b/client/src/components/Nav.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+export default function Nav() {
+  return (
+    <nav className="bg-white shadow mb-4">
+      <div className="container mx-auto px-4 py-2 flex space-x-4">
+        <Link to="/" className="font-bold">Video Stories</Link>
+        <Link to="/prompts">Prompts</Link>
+        <Link to="/stories">Stories</Link>
+        <Link to="/profile">Profile</Link>
+        <Link to="/logout" className="ml-auto">Logout</Link>
+      </div>
+    </nav>
+  );
+}

--- a/client/src/components/PromptWorkflow.jsx
+++ b/client/src/components/PromptWorkflow.jsx
@@ -1,0 +1,34 @@
+import React, { useEffect, useState } from 'react';
+import FriendList from './FriendList';
+import PromptRecorder from './PromptRecorder';
+import ResponseRecorder from './ResponseRecorder';
+
+export default function PromptWorkflow() {
+  const [promptId, setPromptId] = useState(() => {
+    return new URLSearchParams(window.location.search).get('prompt') || '';
+  });
+  const [targetFriend, setTargetFriend] = useState(null);
+
+  return (
+    <div>
+      <FriendList onPrompt={(f) => setTargetFriend(f)} />
+      {targetFriend && (
+        <PromptRecorder
+          friend={targetFriend}
+          onFinish={(id) => {
+            setPromptId(id);
+            const url = new URL(window.location);
+            url.searchParams.set('prompt', id);
+            window.history.replaceState(null, '', url);
+            setTargetFriend(null);
+          }}
+        />
+      )}
+      {promptId && (
+        <div className="mt-6">
+          <ResponseRecorder promptId={promptId} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/pages/Home.jsx
+++ b/client/src/pages/Home.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+export default function Home() {
+  return (
+    <div className="container mx-auto p-4 text-center">
+      <h1 className="text-3xl font-bold mb-4">Video Stories</h1>
+      <p className="mb-6">Record and share video prompts with friends and respond with your own stories.</p>
+      <Link
+        to="/login"
+        className="bg-blue-500 text-white px-4 py-2 rounded"
+      >
+        Log In
+      </Link>
+    </div>
+  );
+}

--- a/client/src/pages/Login.jsx
+++ b/client/src/pages/Login.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import LoginForm from '../components/LoginForm';
+
+export default function Login() {
+  return (
+    <div className="container mx-auto p-4">
+      <h1 className="text-2xl font-bold mb-4">Login</h1>
+      <LoginForm />
+    </div>
+  );
+}

--- a/client/src/pages/Logout.jsx
+++ b/client/src/pages/Logout.jsx
@@ -1,0 +1,13 @@
+import React, { useEffect, useState } from 'react';
+
+export default function Logout() {
+  const [done, setDone] = useState(false);
+  useEffect(() => {
+    fetch('api/logout.php').then(() => setDone(true));
+  }, []);
+  return (
+    <div className="container mx-auto p-4 text-center">
+      {done ? <p>You have been logged out.</p> : <p>Logging out...</p>}
+    </div>
+  );
+}

--- a/client/src/pages/ProfilePage.jsx
+++ b/client/src/pages/ProfilePage.jsx
@@ -1,0 +1,32 @@
+import React, { useState, useEffect } from 'react';
+import Profile from '../components/Profile';
+
+export default function ProfilePage() {
+  const [user, setUser] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetch('api/check_login.php')
+      .then(res => res.json())
+      .then(data => {
+        setUser(data.user || null);
+        setLoading(false);
+      });
+  }, []);
+
+  function handleUpdated(u) {
+    setUser(u);
+  }
+
+  if (loading) return null;
+
+  if (!user) {
+    return <p className="p-4">You must be logged in to edit your profile.</p>;
+  }
+
+  return (
+    <div className="container mx-auto p-4">
+      <Profile user={user} onUpdated={handleUpdated} onClose={() => {}} />
+    </div>
+  );
+}

--- a/client/src/pages/Prompts.jsx
+++ b/client/src/pages/Prompts.jsx
@@ -1,0 +1,34 @@
+import React, { useState, useEffect } from 'react';
+import PromptWorkflow from '../components/PromptWorkflow';
+import LoginForm from '../components/LoginForm';
+
+export default function Prompts() {
+  const [authenticated, setAuthenticated] = useState(false);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetch('api/check_login.php')
+      .then(res => res.json())
+      .then(data => {
+        setAuthenticated(data.authenticated);
+        setLoading(false);
+      });
+  }, []);
+
+  if (loading) return null;
+
+  if (!authenticated) {
+    return (
+      <div className="container mx-auto p-4">
+        <LoginForm />
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto p-4">
+      <h1 className="text-2xl font-bold mb-4">Prompts</h1>
+      <PromptWorkflow />
+    </div>
+  );
+}

--- a/client/src/pages/Stories.jsx
+++ b/client/src/pages/Stories.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function Stories() {
+  return (
+    <div className="container mx-auto p-4">
+      <h1 className="text-2xl font-bold mb-4">Stories</h1>
+      <p>Your stories will appear here.</p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `react-router-dom` and implement router
- create navigation bar component
- stub pages for home, login, logout, profile, prompts and stories
- move existing prompt workflow into separate component

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687413dbbae0832697ca3ac3b5dd3315