### PR TITLE
Add basic error pages

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -12,6 +12,10 @@ RewriteRule ^api/([\w-]+)/?$ api/$1.php [QSA,L]
 # Serve uploaded files through secure PHP script
 RewriteRule ^uploads/(.*)$ api/video.php?file=$1 [QSA,L]
 
+# Friendly error pages
+ErrorDocument 404 /errors/404.html
+ErrorDocument 500 /errors/500.html
+
 # Serve built React assets from the build directory
 RewriteRule ^(assets/.*|favicon.ico|manifest.json)$ build/$1 [L]
 

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,100 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "90bbf95869b4e88bf0dc5022e708a458",
+    "packages": [
+        {
+            "name": "phpmailer/phpmailer",
+            "version": "v6.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPMailer/PHPMailer.git",
+                "reference": "bf74d75a1fde6beaa34a0ddae2ec5fce0f72a144"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPMailer/PHPMailer/zipball/bf74d75a1fde6beaa34a0ddae2ec5fce0f72a144",
+                "reference": "bf74d75a1fde6beaa34a0ddae2ec5fce0f72a144",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-filter": "*",
+                "ext-hash": "*",
+                "php": ">=5.5.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+                "doctrine/annotations": "^1.2.6 || ^1.13.3",
+                "php-parallel-lint/php-console-highlighter": "^1.0.0",
+                "php-parallel-lint/php-parallel-lint": "^1.3.2",
+                "phpcompatibility/php-compatibility": "^9.3.5",
+                "roave/security-advisories": "dev-latest",
+                "squizlabs/php_codesniffer": "^3.7.2",
+                "yoast/phpunit-polyfills": "^1.0.4"
+            },
+            "suggest": {
+                "decomplexity/SendOauth2": "Adapter for using XOAUTH2 authentication",
+                "ext-mbstring": "Needed to send email in multibyte encoding charset or decode encoded addresses",
+                "ext-openssl": "Needed for secure SMTP sending and DKIM signing",
+                "greew/oauth2-azure-provider": "Needed for Microsoft Azure XOAUTH2 authentication",
+                "hayageek/oauth2-yahoo": "Needed for Yahoo XOAUTH2 authentication",
+                "league/oauth2-google": "Needed for Google XOAUTH2 authentication",
+                "psr/log": "For optional PSR-3 debug logging",
+                "symfony/polyfill-mbstring": "To support UTF-8 if the Mbstring PHP extension is not enabled (^1.2)",
+                "thenetworg/oauth2-azure": "Needed for Microsoft XOAUTH2 authentication"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PHPMailer\\PHPMailer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-2.1-only"
+            ],
+            "authors": [
+                {
+                    "name": "Marcus Bointon",
+                    "email": "phpmailer@synchromedia.co.uk"
+                },
+                {
+                    "name": "Jim Jagielski",
+                    "email": "jimjag@gmail.com"
+                },
+                {
+                    "name": "Andy Prevost",
+                    "email": "codeworxtech@users.sourceforge.net"
+                },
+                {
+                    "name": "Brent R. Matzelle"
+                }
+            ],
+            "description": "PHPMailer is a full-featured email creation and transfer class for PHP",
+            "support": {
+                "issues": "https://github.com/PHPMailer/PHPMailer/issues",
+                "source": "https://github.com/PHPMailer/PHPMailer/tree/v6.10.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Synchro",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-04-24T15:19:31+00:00"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": {},
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {},
+    "platform-dev": {},
+    "plugin-api-version": "2.6.0"
+}

--- a/errors/404.html
+++ b/errors/404.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Page Not Found</title>
+  <style>
+    body {font-family: Arial, sans-serif; text-align: center; padding: 2rem;}
+    h1 {font-size: 2rem; color: #333;}
+    a {color: #2563eb; text-decoration: none;}
+  </style>
+</head>
+<body>
+  <h1>Sorry, that page isn't here.</h1>
+  <p>The page you requested could not be found.</p>
+  <p><a href="/">Return home</a></p>
+</body>
+</html>

--- a/errors/500.html
+++ b/errors/500.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Server Error</title>
+  <style>
+    body {font-family: Arial, sans-serif; text-align: center; padding: 2rem;}
+    h1 {font-size: 2rem; color: #333;}
+    a {color: #2563eb; text-decoration: none;}
+  </style>
+</head>
+<body>
+  <h1>Something went wrong</h1>
+  <p>We encountered an unexpected error. Please try again later.</p>
+  <p><a href="/">Return home</a></p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add composer lockfile for the PHP backend
- show friendly 404 and 500 pages
- reference those pages from `.htaccess`

## Testing
- `composer validate --no-check-all`
- `php -r "require 'vendor/autoload.php'; echo 'ok';"`

------
https://chatgpt.com/codex/tasks/task_e_687457e3b5348326a672e6bf11bd5199