### PR TITLE
Use extensionless API routes and new login link

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -9,6 +9,9 @@ RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteRule ^api/([\w-]+)/?$ api/$1.php [QSA,L]
 
+# Direct token link for email login
+RewriteRule ^verify-login/([A-Za-z0-9]+)/?$ api/verify_login.php?token=$1 [QSA,L]
+
 # Serve uploaded files through secure PHP script
 RewriteRule ^uploads/(.*)$ api/video.php?file=$1 [QSA,L]
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ This project is a simple web application that allows users to record short video
    endpoints are available.
 
 Uploaded videos are stored in the `uploads/` directory alongside the PHP scripts.
-Apache users should enable `.htaccess` so that HTTP requests are redirected to HTTPS and video files are served through `api/video.php` for authenticated sessions.
+Apache users should enable `.htaccess` so that HTTP requests are redirected to HTTPS and video files are served through `api/video` for authenticated sessions.
 
 ## Login Flow
 
@@ -54,7 +54,7 @@ This simple setup demonstrates recording and playback of user-generated videos f
 ## Apache Configuration
 
 An `.htaccess` file is included to enforce HTTPS and route requests for files in
-`uploads/` through `api/video.php`. Make sure `AllowOverride` is enabled in your
+`uploads/` through `api/video`. Make sure `AllowOverride` is enabled in your
 Apache configuration so these rules take effect. The deployment workflow copies
 both `.htaccess` and `config.php` to the host so these rules and settings are
 applied automatically with each update.

--- a/api/request_login.php
+++ b/api/request_login.php
@@ -38,7 +38,7 @@ if (!is_dir($tokenDir)) {
 }
 $tokenData = ['email' => $email, 'ts' => time()];
 file_put_contents("$tokenDir/$token.json", json_encode($tokenData));
-$link = 'https://' . $_SERVER['HTTP_HOST'] . '/api/verify_login.php?token=' . $token;
+$link = 'https://' . $_SERVER['HTTP_HOST'] . '/verify-login/' . $token;
 // send email using config
 require_once __DIR__ . '/../vendor/autoload.php';
 

--- a/api/upload_prompt.php
+++ b/api/upload_prompt.php
@@ -32,7 +32,7 @@ if ($friendId > 0) {
         }
         $tokenData = ['email' => $friendEmail, 'ts' => time()];
         file_put_contents("$tokenDir/$token.json", json_encode($tokenData));
-        $link = 'https://' . $_SERVER['HTTP_HOST'] . '/api/verify_login.php?token=' . $token . '&prompt=' . rawurlencode($filename);
+        $link = 'https://' . $_SERVER['HTTP_HOST'] . '/verify-login/' . $token . '?prompt=' . rawurlencode($filename);
 
         require_once __DIR__ . '/../vendor/autoload.php';
         $subject = 'New video prompt';

--- a/api/verify_login.php
+++ b/api/verify_login.php
@@ -16,7 +16,7 @@ if ($token !== '' && file_exists($tokenFile)) {
         header('Content-Type: text/html; charset=UTF-8');
         echo '<!DOCTYPE html><html><body>';
         echo '<p>Login link expired. Request a new link below.</p>';
-        echo '<form method="post" action="/api/request_login.php">';
+        echo '<form method="post" action="/api/request_login">';
         echo '<input type="email" name="email" required placeholder="Email" />';
         echo '<button type="submit">Send Login Link</button>';
         echo '</form></body></html>';

--- a/client/src/components/FriendList.jsx
+++ b/client/src/components/FriendList.jsx
@@ -4,7 +4,7 @@ export default function FriendList({ onPrompt }) {
   const [friends, setFriends] = useState([]);
 
   useEffect(() => {
-    fetch('api/list_friends.php')
+    fetch('api/list_friends')
       .then((res) => res.json())
       .then((data) => setFriends(data));
   }, []);

--- a/client/src/components/LoginForm.jsx
+++ b/client/src/components/LoginForm.jsx
@@ -9,7 +9,7 @@ export default function LoginForm() {
     e.preventDefault();
     const formData = new FormData();
     formData.append('email', email);
-    const res = await fetch('api/request_login.php', {
+    const res = await fetch('api/request_login', {
       method: 'POST',
       body: formData,
     });

--- a/client/src/components/Profile.jsx
+++ b/client/src/components/Profile.jsx
@@ -11,7 +11,7 @@ export default function Profile({ user, onUpdated, onClose }) {
     const formData = new FormData();
     formData.append('username', username);
     if (avatar) formData.append('avatar', avatar);
-    const res = await fetch('api/update_profile.php', {
+    const res = await fetch('api/update_profile', {
       method: 'POST',
       body: formData,
     });

--- a/client/src/components/PromptRecorder.jsx
+++ b/client/src/components/PromptRecorder.jsx
@@ -8,7 +8,7 @@ export default function PromptRecorder({ friend, onFinish }) {
     const formData = new FormData();
     formData.append('video', blob, 'prompt.mp4');
     formData.append('friend_id', friend.id);
-    const res = await fetch('api/upload_prompt.php', {
+    const res = await fetch('api/upload_prompt', {
       method: 'POST',
       body: formData,
     });

--- a/client/src/components/ResponseRecorder.jsx
+++ b/client/src/components/ResponseRecorder.jsx
@@ -7,7 +7,7 @@ export default function ResponseRecorder({ promptId }) {
   async function handleRecorded(blob) {
     const formData = new FormData();
     formData.append('video', blob, 'response.mp4');
-    await fetch(`api/upload_response.php?prompt=${promptId}`, {
+    await fetch(`api/upload_response?prompt=${promptId}`, {
       method: 'POST',
       body: formData,
     });
@@ -15,7 +15,7 @@ export default function ResponseRecorder({ promptId }) {
   }
 
   async function loadResponses() {
-    const res = await fetch(`api/list_responses.php?prompt=${promptId}`);
+    const res = await fetch(`api/list_responses?prompt=${promptId}`);
     const data = await res.json();
     setResponses(data);
   }
@@ -28,7 +28,7 @@ export default function ResponseRecorder({ promptId }) {
     <div>
       <h2 className="text-xl mb-2">Respond to Prompt</h2>
       <video
-        src={`api/video.php?file=${encodeURIComponent(promptId)}`}
+        src={`api/video?file=${encodeURIComponent(promptId)}`}
         controls
         className="w-full mb-4"
       />
@@ -38,7 +38,7 @@ export default function ResponseRecorder({ promptId }) {
         {responses.map((r, i) => (
           <li key={i} className="mb-2">
             <video
-              src={`api/video.php?file=${encodeURIComponent(r.filename)}`}
+              src={`api/video?file=${encodeURIComponent(r.filename)}`}
               controls
               className="w-full"
             />

--- a/client/src/pages/Logout.jsx
+++ b/client/src/pages/Logout.jsx
@@ -3,7 +3,7 @@ import React, { useEffect, useState } from 'react';
 export default function Logout() {
   const [done, setDone] = useState(false);
   useEffect(() => {
-    fetch('api/logout.php').then(() => setDone(true));
+    fetch('api/logout').then(() => setDone(true));
   }, []);
   return (
     <div className="container mx-auto p-4 text-center">

--- a/client/src/pages/ProfilePage.jsx
+++ b/client/src/pages/ProfilePage.jsx
@@ -6,7 +6,7 @@ export default function ProfilePage() {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    fetch('api/check_login.php')
+    fetch('api/check_login')
       .then(res => res.json())
       .then(data => {
         setUser(data.user || null);

--- a/client/src/pages/Prompts.jsx
+++ b/client/src/pages/Prompts.jsx
@@ -7,7 +7,7 @@ export default function Prompts() {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    fetch('api/check_login.php')
+    fetch('api/check_login')
       .then(res => res.json())
       .then(data => {
         setAuthenticated(data.authenticated);


### PR DESCRIPTION
## Summary
- send login links using `/verify-login/{token}`
- rewrite `/verify-login/<token>` to API
- call API routes without `.php` extensions
- update docs for new video route

## Testing
- `npm run build --silent`
- `find api -name '*.php' -print0 | xargs -0 -n1 php -l`

------
https://chatgpt.com/codex/tasks/task_e_6874730397c883268259541530f9f6b6