### PR TITLE
Implement full-screen recording workflow

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -6,11 +6,12 @@ import Logout from './pages/Logout';
 import Prompts from './pages/Prompts';
 import Stories from './pages/Stories';
 import ProfilePage from './pages/ProfilePage';
+import RecordPrompt from './pages/RecordPrompt';
 import Nav from './components/Nav';
 
 function AppRoutes() {
   const location = useLocation();
-  const showNav = location.pathname !== '/';
+  const showNav = location.pathname !== '/' && !location.pathname.startsWith('/record');
   return (
     <>
       {showNav && <Nav />}
@@ -21,6 +22,7 @@ function AppRoutes() {
         <Route path="/prompts" element={<Prompts />} />
         <Route path="/stories" element={<Stories />} />
         <Route path="/profile" element={<ProfilePage />} />
+        <Route path="/record/:friendId" element={<RecordPrompt />} />
       </Routes>
     </>
   );

--- a/client/src/components/FriendList.jsx
+++ b/client/src/components/FriendList.jsx
@@ -1,6 +1,8 @@
 import React, { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 
-export default function FriendList({ onPrompt }) {
+export default function FriendList() {
+  const navigate = useNavigate();
   const [friends, setFriends] = useState([]);
 
   useEffect(() => {
@@ -30,7 +32,7 @@ export default function FriendList({ onPrompt }) {
             </div>
             <button
               className="ml-auto text-xl"
-              onClick={() => onPrompt && onPrompt(f)}
+              onClick={() => navigate(`/record/${f.id}`, { state: { friend: f } })}
               title="Send prompt"
             >
               💬

--- a/client/src/components/PromptRecorder.jsx
+++ b/client/src/components/PromptRecorder.jsx
@@ -3,7 +3,7 @@ import VideoRecorder from './VideoRecorder';
 
 export default function PromptRecorder({ friend, onFinish }) {
   const [uploading, setUploading] = useState(false);
-  async function handleRecorded(blob) {
+  async function handleRecorded(blob /*, url */) {
     setUploading(true);
     const formData = new FormData();
     formData.append('video', blob, 'prompt.mp4');

--- a/client/src/components/PromptWorkflow.jsx
+++ b/client/src/components/PromptWorkflow.jsx
@@ -1,29 +1,16 @@
 import React, { useEffect, useState } from 'react';
 import FriendList from './FriendList';
-import PromptRecorder from './PromptRecorder';
 import ResponseRecorder from './ResponseRecorder';
 
 export default function PromptWorkflow() {
   const [promptId, setPromptId] = useState(() => {
     return new URLSearchParams(window.location.search).get('prompt') || '';
   });
-  const [targetFriend, setTargetFriend] = useState(null);
+
 
   return (
     <div>
-      <FriendList onPrompt={(f) => setTargetFriend(f)} />
-      {targetFriend && (
-        <PromptRecorder
-          friend={targetFriend}
-          onFinish={(id) => {
-            setPromptId(id);
-            const url = new URL(window.location);
-            url.searchParams.set('prompt', id);
-            window.history.replaceState(null, '', url);
-            setTargetFriend(null);
-          }}
-        />
-      )}
+      <FriendList />
       {promptId && (
         <div className="mt-6">
           <ResponseRecorder promptId={promptId} />

--- a/client/src/components/ResponseRecorder.jsx
+++ b/client/src/components/ResponseRecorder.jsx
@@ -4,7 +4,7 @@ import VideoRecorder from './VideoRecorder';
 export default function ResponseRecorder({ promptId }) {
   const [responses, setResponses] = useState([]);
 
-  async function handleRecorded(blob) {
+  async function handleRecorded(blob /*, url */) {
     const formData = new FormData();
     formData.append('video', blob, 'response.mp4');
     await fetch(`api/upload_response?prompt=${promptId}`, {

--- a/client/src/components/VideoRecorder.jsx
+++ b/client/src/components/VideoRecorder.jsx
@@ -30,7 +30,10 @@ export default function VideoRecorder({ onRecorded }) {
 
   async function startRecording() {
     if (!streamRef.current) return;
-    setRecordedUrl(null);
+    if (recordedUrl) {
+      URL.revokeObjectURL(recordedUrl);
+      setRecordedUrl(null);
+    }
     const preferredMime = MediaRecorder.isTypeSupported('video/mp4') ? 'video/mp4' : 'video/webm';
     mediaRecorderRef.current = new MediaRecorder(streamRef.current, { mimeType: preferredMime });
     mediaRecorderRef.current.ondataavailable = (e) => chunksRef.current.push(e.data);
@@ -43,7 +46,7 @@ export default function VideoRecorder({ onRecorded }) {
       videoRef.current.srcObject = null;
       videoRef.current.src = url;
       videoRef.current.muted = false;
-      onRecorded(blob);
+      if (onRecorded) onRecorded(blob, url);
     };
     mediaRecorderRef.current.start();
     setRecording(true);
@@ -67,11 +70,17 @@ export default function VideoRecorder({ onRecorded }) {
       />
       {!recordedUrl && (
         <button
-          className="absolute bottom-4 left-1/2 -translate-x-1/2 bg-yellow-400 rounded-full w-16 h-16"
-          onPointerDown={startRecording}
-          onPointerUp={stopRecording}
-          onPointerLeave={stopRecording}
-        />
+          className="absolute bottom-4 left-1/2 -translate-x-1/2 flex items-center justify-center"
+          onClick={recording ? stopRecording : startRecording}
+        >
+          {recording ? (
+            <span className="block rounded-full border-4 border-red-600 w-16 h-16 flex items-center justify-center">
+              <span className="bg-red-600 w-6 h-6"></span>
+            </span>
+          ) : (
+            <span className="block rounded-full bg-red-600 w-16 h-16"></span>
+          )}
+        </button>
       )}
     </div>
   );

--- a/client/src/pages/RecordPrompt.jsx
+++ b/client/src/pages/RecordPrompt.jsx
@@ -1,0 +1,85 @@
+import React, { useState, useEffect } from 'react';
+import { useParams, useNavigate, useLocation } from 'react-router-dom';
+import VideoRecorder from '../components/VideoRecorder';
+
+export default function RecordPrompt() {
+  const { friendId } = useParams();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const [friend, setFriend] = useState(location.state?.friend || null);
+  const [recordedBlob, setRecordedBlob] = useState(null);
+  const [recordedUrl, setRecordedUrl] = useState(null);
+  const [uploading, setUploading] = useState(false);
+
+  useEffect(() => {
+    if (!friend) {
+      fetch('api/list_friends')
+        .then(res => res.json())
+        .then(data => {
+          const f = data.find(fr => String(fr.id) === String(friendId));
+          setFriend(f);
+        });
+    }
+  }, [friend, friendId]);
+
+  function handleRecorded(blob, url) {
+    setRecordedBlob(blob);
+    setRecordedUrl(url);
+  }
+
+  async function sendVideo() {
+    if (!recordedBlob || !friend) return;
+    setUploading(true);
+    const formData = new FormData();
+    formData.append('video', recordedBlob, 'prompt.mp4');
+    formData.append('friend_id', friend.id);
+    await fetch('api/upload_prompt', {
+      method: 'POST',
+      body: formData,
+    });
+    setUploading(false);
+    navigate('/prompts');
+  }
+
+  function discard() {
+    navigate('/prompts');
+  }
+
+  function rerecord() {
+    if (recordedUrl) {
+      URL.revokeObjectURL(recordedUrl);
+    }
+    setRecordedBlob(null);
+    setRecordedUrl(null);
+  }
+
+  if (!friend) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black flex flex-col items-center justify-center">
+      {uploading ? (
+        <div className="text-white">Uploading...</div>
+      ) : recordedBlob ? (
+        <div className="w-full h-full relative flex flex-col">
+          <video src={recordedUrl} controls className="flex-1 bg-black object-contain" />
+          <div className="absolute bottom-24 left-0 right-0 flex justify-center space-x-8">
+            <button onClick={discard} className="flex flex-col items-center">
+              <span className="w-12 h-12 rounded-full bg-red-600 flex items-center justify-center text-white text-xl">🗑️</span>
+              <span className="text-red-400 text-sm mt-1">Discard</span>
+            </button>
+            <button onClick={rerecord} className="flex flex-col items-center">
+              <span className="w-12 h-12 rounded-full bg-yellow-400 flex items-center justify-center text-xl">🔄</span>
+              <span className="text-yellow-300 text-sm mt-1">Re-record</span>
+            </button>
+            <button onClick={sendVideo} className="flex flex-col items-center">
+              <span className="w-12 h-12 rounded-full bg-green-600 flex items-center justify-center text-white text-xl">📤</span>
+              <span className="text-green-400 text-sm mt-1">Send</span>
+            </button>
+          </div>
+        </div>
+      ) : (
+        <VideoRecorder onRecorded={handleRecorded} />
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- hide navigation while recording prompts
- redirect friend prompt button to a full-screen recording page
- update video recorder button and callback signature
- add new `RecordPrompt` page for recording, previewing, and sending prompts
- simplify prompt workflow to only list friends and show responses

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6876b2023d3c83269e37f30cf12c0453